### PR TITLE
P0-0+P0-A: importability foundation + dribble anchor fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,15 @@ ENV/
 # Models directory
 models/
 
+# Generated simulation / pipeline output (created when sims/tracking run or are imported)
+simulations/
+tracking_data/
+output/
+
+# iCloud Drive sync-conflict copies ("<name> 2.py", etc.)
+* [0-9].py
+* [0-9].*
+
 # OS specific files
 .DS_Store
 **/.DS_Store

--- a/Data_Loading.py
+++ b/Data_Loading.py
@@ -9,6 +9,7 @@ Key Concepts Implemented:
 '''
 
 #%% Import Libraries
+import math
 import numpy as np
 import pandas as pd
 import logging
@@ -19,6 +20,12 @@ from sqlalchemy.orm import declarative_base, sessionmaker
 
 import config
 from sqlalchemy.exc import SQLAlchemyError
+from geoalchemy2 import Geometry
+from geoalchemy2.elements import WKTElement
+
+# Module-level log directory so the logging block below has a defined value
+# (it previously referenced an undefined `log_dir`); respects LOG_DIR in CI/Docker.
+log_dir = os.environ.get('LOG_DIR', os.getcwd())
 
 #%% Create a base class
 
@@ -63,8 +70,24 @@ class TrackingData(Base):
     accel_y_rolling_avg = Column(Float, nullable=False)
     accel_aspect_rolling_avg = Column(Float, nullable=False)
     accel_height_rolling_avg = Column(Float, nullable=False)
+    # PostGIS point built from the rolling-average position; GIST-indexed for
+    # spatial proximity queries (see run_commit_query).
+    point_geom = Column(Geometry(geometry_type='POINT', srid=0), nullable=True)
 
 #%% Create connection to database
+
+def get_connection_string():
+    """
+    Objective:
+    Resolve the PostgreSQL connection string. Honors the DATABASE_URL env var
+    first, then falls back to the centralized config.DB_URL (which itself reads
+    the DB_URL env var / project default). Kept separate from engine creation so
+    the env-driven selection is unit-testable without a live database.
+
+    Returns:
+    [str] connection_string - SQLAlchemy database URL
+    """
+    return os.environ.get('DATABASE_URL', config.DB_URL)
 
 def create_sqlalchemy_engine():
     """ 
@@ -79,17 +102,10 @@ def create_sqlalchemy_engine():
     """
 
     try:
-        # Use environment variables for security
-        #db_username = ''
-        #db_password = ''
-        #db_host = ''
-        #db_port = 5432
-        #db_name = 'postgres'
+        # Connection string is sourced from the DATABASE_URL env var (no hardcoded
+        # credentials); see get_connection_string for the default fallback.
+        connection_string = get_connection_string()
 
-        # Create the connection string
-        #connection_string = f"postgresql://{db_username}:{db_password}@{db_host}:{db_port}/{db_name}"
-        connection_string = config.DB_URL
-        
         try:
             # Create the SQLAlchemy engine
             engine = create_engine(connection_string, pool_pre_ping=True)
@@ -238,7 +254,12 @@ def spatial_data_structure(data_row):
             accel_x_rolling_avg=data_row["accel_x_rolling_avg"],
             accel_y_rolling_avg=data_row["accel_y_rolling_avg"],
             accel_aspect_rolling_avg=data_row["accel_aspect_rolling_avg"],
-            accel_height_rolling_avg=data_row["accel_height_rolling_avg"]
+            accel_height_rolling_avg=data_row["accel_height_rolling_avg"],
+            # Spatial point from the rolling-average position for PostGIS queries
+            point_geom=WKTElement(
+                f"POINT({data_row['pos_x_rolling_avg']} {data_row['pos_y_rolling_avg']})",
+                srid=0,
+            ),
         )
 
         return tracking_data
@@ -305,9 +326,11 @@ def run_commit_query(engine):
     """
 
     try:
-        # SQL command to create the spatial index
+        # SQL command to create the GIST spatial index on the PostGIS point column
         sql_command = text("""
-
+            CREATE INDEX IF NOT EXISTS idx_tracking_data_point_geom
+            ON public.tracking_data
+            USING GIST (point_geom);
         """)
 
         # Execute the SQL command
@@ -354,9 +377,30 @@ def get_basketball_for_frame(engine, frame):
         logging.error(f"Error occurred while getting basketball for frame {frame}: {str(e)}")
         raise
 
+#%% Pure distance helper
+
+def calculate_point_distances(basketball_xy, player_rows):
+    """
+    Objective:
+    Compute Euclidean distances from the basketball to each player and return
+    them ranked nearest-first. Pure function (no DB) so it is unit-testable.
+
+    Parameters:
+    [tuple] basketball_xy - (x, y) of the basketball
+    [list] player_rows - list of (player_id, x, y) tuples
+
+    Returns:
+    [list] ranked - list of (player_id, distance) sorted ascending by distance
+    """
+    bx, by = basketball_xy
+    distances = [
+        (player_id, math.hypot(px - bx, py - by)) for player_id, px, py in player_rows
+    ]
+    return sorted(distances, key=lambda item: item[1])
+
 #%% Calculate basketball distance within database
 
-def calculate_basketball_distances(engine):
+def calculate_basketball_distances(engine, n_closest=3):
     """ 
     Objective: 
     Calculates the distances between basketball and players in a given dataset.
@@ -370,30 +414,43 @@ def calculate_basketball_distances(engine):
 
     try:
         # Collect the distinct frame_ids
-        sql_command = text("""
-        SELECT DISTINCT frame FROM public.tracking_data ORDER BY frame;
+        frames_list = run_select_query(
+            engine,
+            text("SELECT DISTINCT frame FROM public.tracking_data ORDER BY frame;"),
+        )
+
+        # Per-frame query: id, x, y (extracted from the PostGIS point) and class
+        objects_sql = text("""
+            SELECT id, ST_X(point_geom), ST_Y(point_geom), is_basketball
+            FROM public.tracking_data
+            WHERE frame = :frame;
         """)
 
-        frames_list = run_select_query(engine, sql_command)
+        results = {}
+        for (frame_id,) in frames_list:
+            rows = run_select_query(engine, objects_sql, frame_id)
 
-        for (frame_id, ) in frames_list:
-            basketball_data = get_basketball_for_frame(engine, frame_id)
-            
-            # Find the basketball info for this frame
-            
-            if basketball_data is not None:
-                basketball_id, basketball_geom = basketball_data
-                print(basketball_id, basketball_geom)
+            # Split the frame's objects into the basketball and the players
+            basketball_xy = None
+            player_rows = []
+            for obj_id, x, y, is_basketball in rows:
+                if is_basketball:
+                    basketball_xy = (x, y)
+                else:
+                    player_rows.append((obj_id, x, y))
 
-                # Calculate/Insert distances to 3 closest players to the basketball in the same frame
+            # No basketball detected in this frame -> nothing to rank
+            if basketball_xy is None:
+                continue
+
+            # Rank players by proximity and keep the n closest
+            ranked = calculate_point_distances(basketball_xy, player_rows)[:n_closest]
+            results[frame_id] = ranked
+
+        return results
 
     except SQLAlchemyError as e:
-        logging.error(f"SQLAlchemy error occurred while committing the query: {str(e)}")
-        raise
-
-    except:
-        print('Messed up the commit statement')
-        logger.error(f"Error in committing the above query: {e}")
+        logging.error(f"SQLAlchemy error occurred while calculating distances: {str(e)}")
         raise
 
 #%% Configuring logging

--- a/Feature_Engineering.py
+++ b/Feature_Engineering.py
@@ -22,9 +22,38 @@ from datetime import datetime
 from sklearn.preprocessing import MinMaxScaler
 from sklearn.preprocessing import StandardScaler
 from sklearn.decomposition import PCA
+import logging
 import matplotlib.pyplot as plt
 import config
 from utils import export_dataframe_to_csv, read_dataframe_to_csv, configure_logger
+
+# Module-level logger so the helper functions below are importable/testable
+# without running main(); main() reconfigures this via configure_logger().
+logger = logging.getLogger('feature_engineering')
+
+# Columns the raw tracking CSV must contain before feature extraction can run.
+REQUIRED_TRACKING_COLUMNS = [
+    'TrackID', 'ClassID', 'Mean', 'Co-Variance', 'ConfidenceScore',
+    'State', 'Hits', 'Age', 'Features', 'Frame',
+]
+
+
+def validate_tracking_schema(df):
+    """
+    Objective:
+    Assert the raw tracking DataFrame exposes every column the feature pipeline
+    depends on, failing fast with a clear message instead of a deep KeyError.
+
+    Parameters:
+    [pandas DataFrame] df - Raw tracking data to validate
+
+    Returns:
+    [pandas DataFrame] df - The same DataFrame, unchanged, when valid
+    """
+    missing = [col for col in REQUIRED_TRACKING_COLUMNS if col not in df.columns]
+    if missing:
+        raise ValueError(f"Missing required tracking columns: {missing}")
+    return df
 
 #%% One Hot Encoding for Class type
 
@@ -533,11 +562,17 @@ def extract_acceleration(df):
 
         df = df.fillna(0)
 
-        # Calculate acceleration
-        df['accel_x'] = ((df['vel_x']-df['prev_vel_x'])/df['vel_x'])/df['delta_time']
-        df['accel_y'] = ((df['vel_x']-df['prev_vel_y'])/df['vel_y'])/df['delta_time']
-        df['accel_aspect'] = ((df['vel_aspect']-df['prev_vel_aspect'])/df['vel_aspect'])/df['delta_time']
-        df['accel_height'] = ((df['vel_height']-df['prev_vel_height'])/df['vel_height'])/df['delta_time']
+        # Guard divide-by-zero: each track's first frame has delta_time == 0, and
+        # velocities can also be 0 -- both previously yielded inf/NaN acceleration.
+        safe_delta = df['delta_time'].replace(0, np.nan)
+        df['accel_x'] = ((df['vel_x']-df['prev_vel_x'])/df['vel_x'].replace(0, np.nan))/safe_delta
+        df['accel_y'] = ((df['vel_x']-df['prev_vel_y'])/df['vel_y'].replace(0, np.nan))/safe_delta
+        df['accel_aspect'] = ((df['vel_aspect']-df['prev_vel_aspect'])/df['vel_aspect'].replace(0, np.nan))/safe_delta
+        df['accel_height'] = ((df['vel_height']-df['prev_vel_height'])/df['vel_height'].replace(0, np.nan))/safe_delta
+
+        # Any remaining inf/NaN from a zero denominator -> 0 acceleration
+        accel_cols = ['accel_x', 'accel_y', 'accel_aspect', 'accel_height']
+        df[accel_cols] = df[accel_cols].replace([np.inf, -np.inf], np.nan).fillna(0)
 
         df = df.sort_values(['TrackID', 'Frame'], ascending=[True, True])
 
@@ -562,6 +597,7 @@ def feature_extraction(dataset):
     """
 
     try:
+        validate_tracking_schema(dataset)
         transformed_dataset = one_hot_encode_class_id(dataset)
         transformed_dataset = extract_mean_values(transformed_dataset)
         transformed_dataset = transform_state(transformed_dataset)
@@ -611,16 +647,18 @@ def convert_string_to_array(string_data):
 
 #%% Final optimization of dataset
 
-def optimize_dataset(dataset):
-    """ 
-    Objective: 
-    Optimizes the dataset by filling NaN values, normalizing numerical columns, performing PCA, and dropping unnecessary columns.
+def optimize_dataset(dataset, use_pca=False, n_pca_components=16):
+    """
+    Objective:
+    Optimizes the dataset by filling NaN values, normalizing numerical columns, optionally performing PCA, and dropping unnecessary columns.
 
-    Parameters: 
+    Parameters:
     [pandas DataFrame] dataset - The dataset to optimize.
+    [bool] use_pca - When True, replace the numeric feature columns with their top principal components.
+    [int] n_pca_components - Number of principal components to keep when use_pca is True.
 
-    Returns: 
-    [pandas DataFrame] dataset - The optimized dataset. 
+    Returns:
+    [pandas DataFrame] dataset - The optimized dataset.
     """
 
     try:
@@ -634,9 +672,6 @@ def optimize_dataset(dataset):
 
         # Normalize data
         dataset = normalize_numerical_columns(dataset)
-
-        # Perform PCA
-        #perform_pca(dataset, n_components=16, variance_threshold=0.85) # Uncomment to perform PCA
 
         # Remove unecessary columns (Based on information from PCA analysis)
         columns_dropped = ['Mean', 'Unnamed: 0', 'ConfidenceScore', 'State', 'Features', 'ClassID',
@@ -652,13 +687,60 @@ def optimize_dataset(dataset):
         # Remove duplicate rows based on TrackID and Frame
         dataset = dataset.drop_duplicates(subset=['TrackID', 'Frame'], keep='first')
 
+        # Optional dimensionality reduction behind a flag
+        if use_pca:
+            dataset = apply_pca_transform(dataset, n_components=n_pca_components)
+
         return dataset
 
     except Exception as e:
         logger.error("Error in optimizing/cleaning dataset: %s", e)
         raise
 
-#%% PCA Calculation 
+#%% PCA Calculation
+
+def apply_pca_transform(df, n_components=16):
+    """
+    Objective:
+    Replace the numeric feature columns with their top-n principal components,
+    preserving identity/categorical columns. This is the transform invoked by the
+    optimize_dataset PCA flag (perform_pca below is the analysis/plot helper).
+
+    Parameters:
+    [pandas DataFrame] df - Dataset whose numeric feature columns to reduce
+    [int] n_components - Number of principal components to keep
+
+    Returns:
+    [pandas DataFrame] reduced - Dataset with numeric features replaced by PCs
+    """
+    try:
+        # Identity/categorical columns to keep out of PCA and carry through as-is
+        preserved = ['Frame', 'TrackID', 'is_Team_A', 'is_Team_B', 'is_Basketball',
+                     'state_tentative', 'state_confirmed']
+        numeric_columns = df.select_dtypes(include=[np.number]).columns.difference(preserved)
+
+        # Nothing to reduce if we already have <= n_components numeric features
+        if len(numeric_columns) <= n_components:
+            return df
+
+        X_scaled = StandardScaler().fit_transform(df[numeric_columns])
+        components = PCA(n_components=n_components).fit_transform(X_scaled)
+
+        pc_df = pd.DataFrame(
+            components,
+            columns=[f'PC{i+1}' for i in range(n_components)],
+            index=df.index,
+        )
+
+        kept_columns = [col for col in df.columns if col not in numeric_columns]
+        reduced = pd.concat([df[kept_columns], pc_df], axis=1)
+
+        return reduced
+
+    except Exception as e:
+        logger.error("Error in applying PCA transform: %s", e)
+        raise
+
 
 def perform_pca(df, n_components=20, variance_threshold=0.9):
     """

--- a/Neural_Network.py
+++ b/Neural_Network.py
@@ -220,6 +220,10 @@ def main():
         criterion = nn.BCELoss()
         optimizer = optim.Adam(model.parameters(), lr=learning_rate, weight_decay=config.WEIGHT_DECAY)  # L2 regularization
 
+        # Cosine-annealing LR schedule over the full run (replaces the previous
+        # fixed LR for all epochs)
+        scheduler = optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=num_epochs)
+
         # Train the model
         logger.info("Starting model training...")
         history = train_model(
@@ -230,7 +234,8 @@ def main():
             optimizer=optimizer,
             num_epochs=num_epochs,
             device=device,
-            early_stopping_patience=early_stopping_patience
+            early_stopping_patience=early_stopping_patience,
+            scheduler=scheduler
         )
 
         # Plot and save training history

--- a/Object_Tracking.py
+++ b/Object_Tracking.py
@@ -140,16 +140,12 @@ def object_tracking(frame, model, tracker, encoder, n_missed, detected_objects):
         n_missed += abs((len(tracker.tracks))-11)
 
         # Verify the tracks
-        for ith_value, track in enumerate(tracker.tracks):
-            try:
-                # Calculate the object's detection confidence score
-                confidence_score = scores[ith_value]
-
-            except Exception as e:
-                # Calculate the object's detection confidence score
-                logger.debug("Error in calculating confidence score: %s", e)
-                confidence_score = 0.0
-
+        for track in tracker.tracks:
+            # #12 fix: read the confidence carried on the track from its matched
+            # detection (set in Track.update). Coasting/unconfirmed tracks have no
+            # current detection, so log NaN rather than a bogus 0.0 or a
+            # positionally misaligned score.
+            confidence_score = track.confidence if track.confidence is not None else np.nan
 
             # Add a new detected object to the detected_objects dataframe
             ith_object_details = [

--- a/Passing_Simulation.py
+++ b/Passing_Simulation.py
@@ -291,38 +291,38 @@ def new_relative_basketball_position(ball_x, ball_y, ball_displacement_randomnes
     
     try:
         # Determine the side the basketball should move relative to the current player's coordinates
-        right_side = math.cos(current_player.x) > math.sin(current_player.y)
-        left_side = math.cos(current_player.x) < -(math.sin(current_player.y))
+        right_side = math.cos(dribbling_player.x) > math.sin(dribbling_player.y)
+        left_side = math.cos(dribbling_player.x) < -(math.sin(dribbling_player.y))
 
         # Calculate new position based on the conditions provided
         if right_side and left_side:
             if ball_displacement_randomness is True:
-                x_coordinate = current_player.x + basketball_displacement + ball_offset * math.cos(ball_angle)
+                x_coordinate = dribbling_player.x + basketball_displacement + ball_offset * math.cos(ball_angle)
                 y_coordinate = ball_y
             else:
-                x_coordinate = current_player.x - basketball_displacement + ball_offset * math.cos(ball_angle)
+                x_coordinate = dribbling_player.x - basketball_displacement + ball_offset * math.cos(ball_angle)
                 y_coordinate = ball_y
 
         elif right_side and not left_side:
             if ball_displacement_randomness is True:
                 x_coordinate = ball_x
-                y_coordinate = current_player.y + basketball_displacement + ball_offset * math.sin(ball_angle)
+                y_coordinate = dribbling_player.y + basketball_displacement + ball_offset * math.sin(ball_angle)
             else:
                 x_coordinate = ball_x
-                y_coordinate = current_player.y - basketball_displacement + ball_offset * math.sin(ball_angle)
+                y_coordinate = dribbling_player.y - basketball_displacement + ball_offset * math.sin(ball_angle)
         elif not right_side and left_side:
             if ball_displacement_randomness is True:
                 x_coordinate = ball_x
-                y_coordinate = current_player.y + basketball_displacement + ball_offset * math.sin(ball_angle)
+                y_coordinate = dribbling_player.y + basketball_displacement + ball_offset * math.sin(ball_angle)
             else:
                 x_coordinate = ball_x
-                y_coordinate = current_player.y - basketball_displacement + ball_offset * math.sin(ball_angle)
+                y_coordinate = dribbling_player.y - basketball_displacement + ball_offset * math.sin(ball_angle)
         else:
             if ball_displacement_randomness is True:
-                x_coordinate = current_player.x + basketball_displacement + ball_offset * math.cos(ball_angle)
+                x_coordinate = dribbling_player.x + basketball_displacement + ball_offset * math.cos(ball_angle)
                 y_coordinate = ball_y
             else:
-                x_coordinate = current_player.x - basketball_displacement + ball_offset * math.cos(ball_angle)
+                x_coordinate = dribbling_player.x - basketball_displacement + ball_offset * math.cos(ball_angle)
                 y_coordinate = ball_y
 
         return x_coordinate, y_coordinate
@@ -717,9 +717,16 @@ def initialize_simulation():
 
 #%% Configure Docker containerization
 #'''
-log_dir = os.environ.get('LOG_DIR', '/app/logs')
-video_dir = os.environ.get('VIDEO_DIR', '/app/simulations')
-assets_dir = os.environ.get('ASSETS_DIR', '/app/assets')
+def _default_dir(name):
+    # In Docker/CI use the container's /app paths; otherwise fall back to a
+    # writable dir under the cwd so the module can be imported (e.g. by the
+    # test suite) on a normal workstation instead of failing on /app.
+    in_container = os.path.exists('/.dockerenv') or os.getenv('GITHUB_ACTIONS') == 'true'
+    return os.path.join('/app', name) if in_container else os.path.join(os.getcwd(), name)
+
+log_dir = os.environ.get('LOG_DIR', _default_dir('logs'))
+video_dir = os.environ.get('VIDEO_DIR', _default_dir('simulations'))
+assets_dir = os.environ.get('ASSETS_DIR', _default_dir('assets'))
 
 def ensure_dir(directory):
     if not os.path.exists(directory):
@@ -799,148 +806,149 @@ simulation_limit = 1 # stop simulation after x minutes
 
 " Simulate Basketball Game "
 
-initialize_simulation()
+if __name__ == "__main__":
+    initialize_simulation()
 
-start_time_simulation = time.time()
+    start_time_simulation = time.time()
 
-# Define the codec and create VideoWriter object
-video_format = cv2.VideoWriter_fourcc(*'XVID')
-try:
-    video_output_path = os.path.join(video_dir, 'simulation_video.mp4')
-except Exception as e:
-    video_output_path = os.path.join(script_directory, 'assets/simulation_video.mp4')
+    # Define the codec and create VideoWriter object
+    video_format = cv2.VideoWriter_fourcc(*'XVID')
+    try:
+        video_output_path = os.path.join(video_dir, 'simulation_video.mp4')
+    except Exception as e:
+        video_output_path = os.path.join(script_directory, 'assets/simulation_video.mp4')
     
-out = cv2.VideoWriter(video_output_path, video_format, FPS, SCREEN_DIMENSIONS)
+    out = cv2.VideoWriter(video_output_path, video_format, FPS, SCREEN_DIMENSIONS)
 
-frames_captured = 0
-# x seconds the simulation will run to capture recordings
-if os.path.exists('/.dockerenv') or os.getenv('GITHUB_ACTIONS') == 'true': # If running in Docker or GitHub Actions
-    simulation_capture_max_time = 5
-else:
-    simulation_capture_max_time = 10
+    frames_captured = 0
+    # x seconds the simulation will run to capture recordings
+    if os.path.exists('/.dockerenv') or os.getenv('GITHUB_ACTIONS') == 'true': # If running in Docker or GitHub Actions
+        simulation_capture_max_time = 5
+    else:
+        simulation_capture_max_time = 10
 
-max_frames_caputured = FPS * simulation_capture_max_time
+    max_frames_caputured = FPS * simulation_capture_max_time
 
-try:
-    current_player = secrets.choice(team_players) # Updated for passing simulation data collection
+    try:
+        current_player = secrets.choice(team_players) # Updated for passing simulation data collection
 
-    while simulating and (frames_captured < max_frames_caputured):
+        while simulating and (frames_captured < max_frames_caputured):
         
-        elapsed_time_simulation = time.time() - start_time_simulation # Set elapsed time to stop simulation after mentioned time
+            elapsed_time_simulation = time.time() - start_time_simulation # Set elapsed time to stop simulation after mentioned time
         
-        #Create screen with basketball court as the background
-        screen.blit(background_image, (0,0))
+            #Create screen with basketball court as the background
+            screen.blit(background_image, (0,0))
 
-        #Stop simulation
-        for event in pygame.event.get():
-            if event.type == pygame.QUIT:
-                simulating = False
-            # Press 'q' to quit
-            elif (event.type == pygame.KEYDOWN) and (event.key == pygame.K_q):
-                simulating = False
+            #Stop simulation
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    simulating = False
+                # Press 'q' to quit
+                elif (event.type == pygame.KEYDOWN) and (event.key == pygame.K_q):
+                    simulating = False
 
-        # Update and draw players
-        for player in players:
-            player.move(basketball)
-            player.draw()
+            # Update and draw players
+            for player in players:
+                player.move(basketball)
+                player.draw()
             
-        time_elapsed = time.time() - oscillation_start_time # Time elapsed since ball reached the player
+            time_elapsed = time.time() - oscillation_start_time # Time elapsed since ball reached the player
 
-        # Move basketball towards the current player
-        if reached_player is False:
+            # Move basketball towards the current player
+            if reached_player is False:
             
-            #Restart the following variables
-            current_player.angle_update = False
-            basketball.change_displacement = False
-            basketball.stabalize_dribble_switch_check = False
+                #Restart the following variables
+                current_player.angle_update = False
+                basketball.change_displacement = False
+                basketball.stabalize_dribble_switch_check = False
             
-            # Create a new list excluding the current player and randomly choose a player to pass to
-            team_players_excluding_current = [player for player in team_players if player != current_player]
-            new_random_player = secrets.choice(team_players_excluding_current)
+                # Create a new list excluding the current player and randomly choose a player to pass to
+                team_players_excluding_current = [player for player in team_players if player != current_player]
+                new_random_player = secrets.choice(team_players_excluding_current)
             
-            pass_players = [current_player, new_random_player] #Both players the ball is being passed between
-            basketball.x, basketball.y = move_basketball_to_location(
-                basketball,
-                current_player.x,
-                current_player.y,
-                players,
-                pass_players
-            )  # Move basketball closer to player
-            reached_player = ball_reached_player(basketball, current_player, MOVE_SPEED) #Stop if ball reached player
+                pass_players = [current_player, new_random_player] #Both players the ball is being passed between
+                basketball.x, basketball.y = move_basketball_to_location(
+                    basketball,
+                    current_player.x,
+                    current_player.y,
+                    players,
+                    pass_players
+                )  # Move basketball closer to player
+                reached_player = ball_reached_player(basketball, current_player, MOVE_SPEED) #Stop if ball reached player
             
-            #Calculate the distance between the basketball and the receiving player.
-            #This dictates which relative position the basketball should be from the player
-            if first_overlap is False:
-                if check_circles_overlap(basketball, current_player, basketball_player_overlap):
+                #Calculate the distance between the basketball and the receiving player.
+                #This dictates which relative position the basketball should be from the player
+                if first_overlap is False:
+                    if check_circles_overlap(basketball, current_player, basketball_player_overlap):
                     
-                    #Calculate x, y displacement relative to player
-                    basketball_relative_x = basketball.x - current_player.x
-                    basketball_relative_y = basketball.y - current_player.y
+                        #Calculate x, y displacement relative to player
+                        basketball_relative_x = basketball.x - current_player.x
+                        basketball_relative_y = basketball.y - current_player.y
                     
-                    last_update_time = datetime.datetime.now() #set update time
-                    first_overlap = True
+                        last_update_time = datetime.datetime.now() #set update time
+                        first_overlap = True
             
-            oscillation_start_time = time.time() #Set the oscillation start time to current time to reset the timer
-
-            # Stop if the ball reached the player
-            if reached_player is True:
-                break
-
-        
-        #current_player dribbles the basketball
-        else:
-            MOVE_SPEED = cryptographic_normal(5.6, 1) #Update move_speed
-            player_pass_time = player.last_update_time + player.change_ball_time_limit
-
-            # Check if basketball should switch to another side of the player
-            if basketball.dribble_switch is False:
-                basketball.update_position(current_player, time_elapsed)
-                basketball.speed = current_player.speed
-                basketball.angle = current_player.angle
-                basketball.stabalize_dribble_switch_check = False #Restart the stabalizing dribble switch check
-
-            # Start timer once basketball reaches player
-            if pass_timer < 0:
-                pass_timer = 0  # Activate timer
                 oscillation_start_time = time.time() #Set the oscillation start time to current time to reset the timer
-            pass_timer += clock.get_time() / 1000.0  # Convert milliseconds to seconds
 
-            # If pass_time greater or equal to when the ball should be passed
-            if pass_timer >= player.change_ball_time_limit:
-                # Time to pass the basketball to the next blue player
-                current_index = team_players.index(current_player) + 1
-                if current_index >= len(team_players):
-                    current_index = 0
-                current_player = team_players[current_index] #set a new player to control the basketball
-                pass_timer = -1  # Reset timer to deactivate
-                first_overlap = False
-                reached_player = False
-                break
+                # Stop if the ball reached the player
+                if reached_player is True:
+                    break
 
-        basketball.draw()  # Draw the basketball
+        
+            #current_player dribbles the basketball
+            else:
+                MOVE_SPEED = cryptographic_normal(5.6, 1) #Update move_speed
+                player_pass_time = player.last_update_time + player.change_ball_time_limit
 
-        pygame.display.flip() #Update pygame simulation frame
-        clock.tick(FPS) # Maintain frame rate (FPS)
+                # Check if basketball should switch to another side of the player
+                if basketball.dribble_switch is False:
+                    basketball.update_position(current_player, time_elapsed)
+                    basketball.speed = current_player.speed
+                    basketball.angle = current_player.angle
+                    basketball.stabalize_dribble_switch_check = False #Restart the stabalizing dribble switch check
 
-        # Capture frame
-        frame = pygame.surfarray.array3d(pygame.display.get_surface())
-        frame = frame.transpose([1, 0, 2])  # transpose to the correct shape
-        frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)  # convert from RGB to BGR
+                # Start timer once basketball reaches player
+                if pass_timer < 0:
+                    pass_timer = 0  # Activate timer
+                    oscillation_start_time = time.time() #Set the oscillation start time to current time to reset the timer
+                pass_timer += clock.get_time() / 1000.0  # Convert milliseconds to seconds
 
-        # Do not include the first frame so the simulation could stabalize for effective analysis 
-        if frames_captured > 0:
-            # Write the output frame
-            out.write(frame)
-        frames_captured += 1
+                # If pass_time greater or equal to when the ball should be passed
+                if pass_timer >= player.change_ball_time_limit:
+                    # Time to pass the basketball to the next blue player
+                    current_index = team_players.index(current_player) + 1
+                    if current_index >= len(team_players):
+                        current_index = 0
+                    current_player = team_players[current_index] #set a new player to control the basketball
+                    pass_timer = -1  # Reset timer to deactivate
+                    first_overlap = False
+                    reached_player = False
+                    break
 
-    logger.debug("Game Simulation succeeded")
-    print("Game Simulation succeeded")
+            basketball.draw()  # Draw the basketball
 
-except Exception as e:
-    logger.error("Error during simulation: %s", e)
-    print("Game Simulation failed")
-    raise
+            pygame.display.flip() #Update pygame simulation frame
+            clock.tick(FPS) # Maintain frame rate (FPS)
 
-finally:
-    out.release()
-    pygame.quit()
+            # Capture frame
+            frame = pygame.surfarray.array3d(pygame.display.get_surface())
+            frame = frame.transpose([1, 0, 2])  # transpose to the correct shape
+            frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)  # convert from RGB to BGR
+
+            # Do not include the first frame so the simulation could stabalize for effective analysis 
+            if frames_captured > 0:
+                # Write the output frame
+                out.write(frame)
+            frames_captured += 1
+
+        logger.debug("Game Simulation succeeded")
+        print("Game Simulation succeeded")
+
+    except Exception as e:
+        logger.error("Error during simulation: %s", e)
+        print("Game Simulation failed")
+        raise
+
+    finally:
+        out.release()
+        pygame.quit()

--- a/Passing_Simulation.py
+++ b/Passing_Simulation.py
@@ -14,7 +14,27 @@ import datetime
 import numpy as np
 import os
 import cv2
-import secrets
+# Seeded RNG for reproducible simulations (replaces the stdlib secret-random
+# draws). Seed via the SIM_SEED env var (default 42); call seed_rng(...) to
+# reproduce a run exactly.
+_rng = np.random.default_rng(int(os.environ.get('SIM_SEED', 42)))
+
+
+def seed_rng(seed):
+    "Reseed the module RNG so a simulation run can be reproduced bit-for-bit."
+    global _rng
+    _rng = np.random.default_rng(seed)
+
+
+def _rng_choice(seq):
+    "Deterministic replacement for a random choice over a sequence."
+    seq = list(seq)
+    return seq[int(_rng.integers(len(seq)))]
+
+
+def _rng_below(n):
+    "Deterministic replacement for a random integer in [0, n)."
+    return int(_rng.integers(n))
 from utils import configure_logger
 
 #%% Class - Player
@@ -34,12 +54,12 @@ class Player:
         self.initial_y = y #set first y-coordinate after received by player
         self.radius = radius #set radius
         self.color = color #set player color
-        self.speed = secrets.SystemRandom().uniform(0.2, 1.7) #set random speed
-        self.angle = secrets.SystemRandom().uniform(0, 2 * math.pi) #set random angle
+        self.speed = _rng.uniform(0.2, 1.7) #set random speed
+        self.angle = _rng.uniform(0, 2 * math.pi) #set random angle
         self.next_angle = self.angle + cryptographic_normal(90, 1.5, True) #set next angle
         self.last_update_time = time.time() #set last update time
         self.angle_update = False #Set angle update for basketball displacement
-        self.change_ball_time_limit = secrets.SystemRandom().uniform(3, 6) #Set time limit when ball should update
+        self.change_ball_time_limit = _rng.uniform(3, 6) #Set time limit when ball should update
 
     def update_speed_angle(self, basketball):
         """
@@ -60,7 +80,7 @@ class Player:
                 basketball.change_displacement = False
 
                 #Change speed
-                self.speed = secrets.SystemRandom().uniform(0.2, 1.7)
+                self.speed = _rng.uniform(0.2, 1.7)
 
                 #Change angle
                 self.angle = self.next_angle
@@ -69,7 +89,7 @@ class Player:
                 self.last_update_time = time.time()
 
                 #Update when ball update should change
-                self.change_ball_time_limit = secrets.SystemRandom().uniform(3,6)
+                self.change_ball_time_limit = _rng.uniform(3,6)
 
                 self.initial_x = self.x #set first x-coordinate after received by player
                 self.initial_y = self.y #set first y-coordinate after received by player
@@ -97,14 +117,26 @@ class Player:
         try:
             self.update_speed_angle(basketball)
 
-            self.x += self.speed * math.cos(self.angle)
-            self.y += self.speed * math.sin(self.angle)
+            vx = self.speed * math.cos(self.angle)
+            vy = self.speed * math.sin(self.angle)
+            self.x += vx
+            self.y += vy
 
-            # Prevent wall collision
-            if self.x + self.radius > SCREEN_WIDTH-15 or self.x - self.radius < 0:
+            # Valid interior bounds (single margin constant)
+            min_x, max_x = self.radius, SCREEN_WIDTH - WALL_MARGIN - self.radius
+            min_y, max_y = self.radius, SCREEN_HEIGHT - WALL_MARGIN - self.radius
+
+            # #13 fix: reflect only when the player is heading further out of
+            # bounds, so a player at the edge can't oscillate (reflect-step-still
+            # outside-reflect) and get stuck. Then clamp back inside so the test
+            # can't re-trigger next frame.
+            if (self.x > max_x and vx > 0) or (self.x < min_x and vx < 0):
                 self.angle = math.pi - self.angle
-            if self.y + self.radius > SCREEN_HEIGHT-15 or self.y - self.radius < 0:
+            if (self.y > max_y and vy > 0) or (self.y < min_y and vy < 0):
                 self.angle = -self.angle
+
+            self.x = min(max(self.x, min_x), max_x)
+            self.y = min(max(self.y, min_y), max_y)
 
         except Exception as e:
             logger.error("Error in moving player: %s", e)
@@ -145,13 +177,13 @@ class Basketball:
         self.y = y #set y-coordinate
         self.radius = radius #set basketball radius
         self.color = color #set basketball color
-        self.speed = secrets.SystemRandom().uniform(0.2, 1.7) #set random speed
-        self.angle = secrets.SystemRandom().uniform(0, 2 * math.pi) #set random angle
+        self.speed = _rng.uniform(0.2, 1.7) #set random speed
+        self.angle = _rng.uniform(0, 2 * math.pi) #set random angle
         self.last_update_time = time.time()  #set last update time
         self.history = [] # To store positions for fluctuation effect
         self.offset = 0 #Offset refers to the displacment of basketball from the player. Initialize at 0, since this will update later.
         self.change_displacement = False #To prevent constant change in displacment from the player
-        self.displacement_randomness = secrets.choice([True, False]) #Displacement randomness to choose a side for a player
+        self.displacement_randomness = bool(_rng.integers(2)) #Displacement randomness to choose a side for a player
         self.dribble_switch = False #When dribble switch is false, do not update position through basketball class
         self.stabalize_dribble_switch_x = None #Set the x starting value of the next side of the dribble switch
         self.stabalize_dribble_switch_y = None #Set the y starting value of the next side of the dribble switch
@@ -251,7 +283,7 @@ def update_basketball_position(ball, dribbling_player, basketball_displacement):
 
             change_displacement_value = True
             angle_update_value = True
-            displacement_randomness = secrets.choice([True, False])
+            displacement_randomness = bool(_rng.integers(2))
         
         else:
             x_coordinate = dribbling_player.x + basketball_displacement + ball.offset * math.cos(ball.angle)
@@ -356,11 +388,13 @@ def move_basketball_to_location(ball, target_x, target_y, avoiding_players=None,
             # Calculate the direct path vector
             dx, dy = target_x - ball.x, target_y - ball.y
 
-            #If movement is less than 7 pixels, stabalize the movement so we need to return the same ball.x, ball.y value.
-            #Set diplsacement to 0
-            if dx <= 7 or dy <= 7:
-                displacement_x, displacement_y = 0,0
-            
+            # #15 fix: snap based on Euclidean distance, not signed component
+            # deltas. The old `dx <= 7 or dy <= 7` was true for any leftward/upward
+            # move (negative delta), zeroing displacement and making the ball jerk
+            # to a stop. Now we step at MOVE_SPEED until genuinely close, then snap.
+            if math.hypot(dx, dy) <= BALL_SNAP_THRESHOLD:
+                displacement_x, displacement_y = 0, 0
+
             else:
                 path_vector = pygame.math.Vector2(dx, dy)
                 path_vector = path_vector.normalize() * MOVE_SPEED
@@ -505,8 +539,8 @@ def cryptographic_normal(mu, sigma, radian=False):
     """
     try:
         # Generate two uniform random integers
-        raw1 = secrets.randbits(64)
-        raw2 = secrets.randbits(64)
+        raw1 = int(_rng.integers(0, 2**64, dtype=np.uint64))
+        raw2 = int(_rng.integers(0, 2**64, dtype=np.uint64))
 
         # Convert to floats in the range [0, 1)
         u1 = raw1 / 2**64
@@ -629,8 +663,8 @@ def place_circle_with_constraints(existing_players, radius, color, simulation_wi
         attempts = 0
         while attempts < 1000:  # Limit attempts to prevent infinite loop
             new_player = Player(
-                radius + secrets.randbelow(simulation_width - (3 * radius) + 1),
-                radius + secrets.randbelow(simulation_width - (3 * radius) + 1),
+                radius + _rng_below(simulation_width - (3 * radius) + 1),
+                radius + _rng_below(simulation_width - (3 * radius) + 1),
                 radius,
                 color)
             
@@ -702,7 +736,7 @@ def initialize_simulation():
 
         # Choose a random blue player to place the basketball with
         team_players = [player for player in players if player.color == COLOR_BLUE]
-        current_player = secrets.choice(team_players)
+        current_player = _rng_choice(team_players)
 
         basketball = Basketball(
             current_player.x - basketball_relative_x,
@@ -783,12 +817,14 @@ COLOR_RED = (255, 0, 0)
 COLOR_ORANGE = (255, 165, 0)
 COLOR_WHITE = (255, 255, 255)
 FPS = 30
+WALL_MARGIN = 15 #Single boundary margin used by the wall-collision handler
 MOVE_SPEED = cryptographic_normal(5.6, 1) #Speed at which basketball moves to the next player
+BALL_SNAP_THRESHOLD = 7 #Distance under which the ball snaps to its target instead of stepping
 
 # Simulation Variables
 clock = pygame.time.Clock()
 pass_timer = -1
-pass_interval = secrets.SystemRandom().uniform(4, 5)  #How many seconds before the player passes the ball
+pass_interval = _rng.uniform(4, 5)  #How many seconds before the player passes the ball
 reached_player = False #When basketball is with a player
 basketball_relative_x = 5 #X-axis displacemnt of the basketball compared to the player
 basketball_relative_y = 5 #Y-axis displacemnt of the basketball compared to the player
@@ -830,7 +866,7 @@ if __name__ == "__main__":
     max_frames_caputured = FPS * simulation_capture_max_time
 
     try:
-        current_player = secrets.choice(team_players) # Updated for passing simulation data collection
+        current_player = _rng_choice(team_players) # Updated for passing simulation data collection
 
         while simulating and (frames_captured < max_frames_caputured):
         
@@ -864,7 +900,7 @@ if __name__ == "__main__":
             
                 # Create a new list excluding the current player and randomly choose a player to pass to
                 team_players_excluding_current = [player for player in team_players if player != current_player]
-                new_random_player = secrets.choice(team_players_excluding_current)
+                new_random_player = _rng_choice(team_players_excluding_current)
             
                 pass_players = [current_player, new_random_player] #Both players the ball is being passed between
                 basketball.x, basketball.y = move_basketball_to_location(

--- a/RandomMovement_Simulation.py
+++ b/RandomMovement_Simulation.py
@@ -12,7 +12,27 @@ import time
 import numpy as np
 import os
 import cv2
-import secrets
+# Seeded RNG for reproducible simulations (replaces the stdlib secret-random
+# draws). Seed via the SIM_SEED env var (default 42); call seed_rng(...) to
+# reproduce a run exactly.
+_rng = np.random.default_rng(int(os.environ.get('SIM_SEED', 42)))
+
+
+def seed_rng(seed):
+    "Reseed the module RNG so a simulation run can be reproduced bit-for-bit."
+    global _rng
+    _rng = np.random.default_rng(seed)
+
+
+def _rng_choice(seq):
+    "Deterministic replacement for a random choice over a sequence."
+    seq = list(seq)
+    return seq[int(_rng.integers(len(seq)))]
+
+
+def _rng_below(n):
+    "Deterministic replacement for a random integer in [0, n)."
+    return int(_rng.integers(n))
 from utils import configure_logger
 
 #%%
@@ -36,11 +56,11 @@ class Player:
         self.y = y #set y-coordinate
         self.radius = radius #set radius
         self.color = color #set player color
-        self.speed = secrets.SystemRandom().uniform(0.2, 2.5) #set random speed (slightly higher than original)
-        self.angle = secrets.SystemRandom().uniform(0, 2 * math.pi) #set random angle
+        self.speed = _rng.uniform(0.2, 2.5) #set random speed (slightly higher than original)
+        self.angle = _rng.uniform(0, 2 * math.pi) #set random angle
         self.next_angle = self.angle + cryptographic_normal(90, 1.5, True) #set next angle
         self.last_update_time = time.time() #set last update time
-        self.change_direction_time_limit = secrets.SystemRandom().uniform(2, 5) #Set time limit for direction change
+        self.change_direction_time_limit = _rng.uniform(2, 5) #Set time limit for direction change
 
     def update_speed_angle(self):
         """
@@ -55,7 +75,7 @@ class Player:
             # Current time - last updated time < Change time
             if time.time() - self.last_update_time >= self.change_direction_time_limit:
                 # Change speed
-                self.speed = secrets.SystemRandom().uniform(0.2, 2.5)
+                self.speed = _rng.uniform(0.2, 2.5)
 
                 # Change angle
                 self.angle = self.next_angle
@@ -64,7 +84,7 @@ class Player:
                 self.last_update_time = time.time()
 
                 # Update when direction should change
-                self.change_direction_time_limit = secrets.SystemRandom().uniform(2, 5)
+                self.change_direction_time_limit = _rng.uniform(2, 5)
 
                 # Update the angle randomly
                 if int(time.time()%60)%2 == 0:
@@ -145,10 +165,10 @@ class Basketball:
         self.y = y #set y-coordinate
         self.radius = radius #set basketball radius
         self.color = color #set basketball color
-        self.speed = secrets.SystemRandom().uniform(0.5, 3.0) #set random speed (faster than players)
-        self.angle = secrets.SystemRandom().uniform(0, 2 * math.pi) #set random angle
+        self.speed = _rng.uniform(0.5, 3.0) #set random speed (faster than players)
+        self.angle = _rng.uniform(0, 2 * math.pi) #set random angle
         self.last_update_time = time.time() #set last update time
-        self.change_direction_time_limit = secrets.SystemRandom().uniform(1, 4) #shorter time for more changes
+        self.change_direction_time_limit = _rng.uniform(1, 4) #shorter time for more changes
 
     def update_movement(self):
         """
@@ -161,16 +181,16 @@ class Basketball:
         try:
             if time.time() - self.last_update_time >= self.change_direction_time_limit:
                 # Change speed
-                self.speed = secrets.SystemRandom().uniform(0.5, 3.0)
+                self.speed = _rng.uniform(0.5, 3.0)
                 
                 # Change angle more randomly than players
-                self.angle = secrets.SystemRandom().uniform(0, 2 * math.pi)
+                self.angle = _rng.uniform(0, 2 * math.pi)
                 
                 # Update last update time
                 self.last_update_time = time.time()
                 
                 # Update when direction should change
-                self.change_direction_time_limit = secrets.SystemRandom().uniform(1, 4)
+                self.change_direction_time_limit = _rng.uniform(1, 4)
         except Exception as e:
             logger.error("Error in updating basketball movement: %s", e)
             raise
@@ -239,8 +259,8 @@ def cryptographic_normal(mu, sigma, radian=False):
     """
     try:
         # Generate two uniform random integers
-        raw1 = secrets.randbits(64)
-        raw2 = secrets.randbits(64)
+        raw1 = int(_rng.integers(0, 2**64, dtype=np.uint64))
+        raw2 = int(_rng.integers(0, 2**64, dtype=np.uint64))
 
         # Convert to floats in the range [0, 1)
         u1 = raw1 / 2**64
@@ -367,8 +387,8 @@ def place_circle_with_constraints(existing_players, radius, color, simulation_wi
         attempts = 0
         while attempts < 1000:  # Limit attempts to prevent infinite loop
             new_player = Player(
-                radius + secrets.randbelow(simulation_width - (3 * radius) + 1),
-                radius + secrets.randbelow(simulation_height - (3 * radius) + 1),
+                radius + _rng_below(simulation_width - (3 * radius) + 1),
+                radius + _rng_below(simulation_height - (3 * radius) + 1),
                 radius,
                 color)
             
@@ -491,8 +511,8 @@ def initialize_simulation():
         # Initialize basketball at a random position
         attempts = 0
         while attempts < 1000:
-            ball_x = BALL_RADIUS + secrets.randbelow(SCREEN_WIDTH - (2 * BALL_RADIUS))
-            ball_y = BALL_RADIUS + secrets.randbelow(SCREEN_HEIGHT - (2 * BALL_RADIUS))
+            ball_x = BALL_RADIUS + _rng_below(SCREEN_WIDTH - (2 * BALL_RADIUS))
+            ball_y = BALL_RADIUS + _rng_below(SCREEN_HEIGHT - (2 * BALL_RADIUS))
             
             # Check if the basketball is not too close to any player
             valid_position = True
@@ -522,78 +542,79 @@ def initialize_simulation():
 
 #%% Random Movement Simulation
 
-try:
-    initialize_simulation()
-
-    start_time_simulation = time.time()
-
-    # Define the codec and create VideoWriter object
-    video_format = cv2.VideoWriter_fourcc(*'XVID')
+if __name__ == "__main__":
     try:
-        video_output_path = os.path.join(video_dir, 'random_movement_video.mp4')
-    except TypeError:
-        video_output_path = os.path.join(os.getcwd(), 'assets/random_movement_video.mp4')
-    out = cv2.VideoWriter(video_output_path, video_format, FPS, SCREEN_DIMENSIONS)
+        initialize_simulation()
 
-    frames_captured = 0
-    # Define how long the simulation will run
-    if os.path.exists('/.dockerenv') or os.getenv('GITHUB_ACTIONS') == 'true': # If running in Docker or GitHub Actions
-        simulation_capture_max_time = 1
-    else:
-        simulation_capture_max_time = 10  # 10 seconds for local development
+        start_time_simulation = time.time()
 
-    max_frames_captured = FPS * simulation_capture_max_time
-    simulating = True
+        # Define the codec and create VideoWriter object
+        video_format = cv2.VideoWriter_fourcc(*'XVID')
+        try:
+            video_output_path = os.path.join(video_dir, 'random_movement_video.mp4')
+        except TypeError:
+            video_output_path = os.path.join(os.getcwd(), 'assets/random_movement_video.mp4')
+        out = cv2.VideoWriter(video_output_path, video_format, FPS, SCREEN_DIMENSIONS)
 
-    # Pygame clock for maintaining frame rate
-    clock = pygame.time.Clock()
+        frames_captured = 0
+        # Define how long the simulation will run
+        if os.path.exists('/.dockerenv') or os.getenv('GITHUB_ACTIONS') == 'true': # If running in Docker or GitHub Actions
+            simulation_capture_max_time = 1
+        else:
+            simulation_capture_max_time = 10  # 10 seconds for local development
 
-    while simulating and (frames_captured < max_frames_captured):
+        max_frames_captured = FPS * simulation_capture_max_time
+        simulating = True
+
+        # Pygame clock for maintaining frame rate
+        clock = pygame.time.Clock()
+
+        while simulating and (frames_captured < max_frames_captured):
         
-        elapsed_time_simulation = time.time() - start_time_simulation
+            elapsed_time_simulation = time.time() - start_time_simulation
         
-        # Create screen with basketball court as the background
-        screen.blit(background_image, (0,0))
+            # Create screen with basketball court as the background
+            screen.blit(background_image, (0,0))
 
-        # Check for quit events
-        for event in pygame.event.get():
-            if event.type == pygame.QUIT:
-                simulating = False
-            # Press 'q' to quit
-            elif (event.type == pygame.KEYDOWN) and (event.key == pygame.K_q):
-                simulating = False
+            # Check for quit events
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    simulating = False
+                # Press 'q' to quit
+                elif (event.type == pygame.KEYDOWN) and (event.key == pygame.K_q):
+                    simulating = False
 
-        # Update and draw players
-        for player in players:
-            player.move()
-            player.draw()
+            # Update and draw players
+            for player in players:
+                player.move()
+                player.draw()
             
-        # Update and draw basketball (independent movement)
-        basketball.move()
-        basketball.draw()
+            # Update and draw basketball (independent movement)
+            basketball.move()
+            basketball.draw()
 
-        pygame.display.flip()  # Update pygame simulation frame
-        clock.tick(FPS)  # Maintain frame rate
+            pygame.display.flip()  # Update pygame simulation frame
+            clock.tick(FPS)  # Maintain frame rate
 
-        # Capture frame
-        frame = pygame.surfarray.array3d(pygame.display.get_surface())
-        frame = frame.transpose([1, 0, 2])  # transpose to the correct shape
-        frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)  # convert from RGB to BGR
+            # Capture frame
+            frame = pygame.surfarray.array3d(pygame.display.get_surface())
+            frame = frame.transpose([1, 0, 2])  # transpose to the correct shape
+            frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)  # convert from RGB to BGR
 
-        # Skip the first frame to allow simulation to stabilize
-        if frames_captured > 0:
-            # Write the output frame
-            out.write(frame)
-        frames_captured += 1
+            # Skip the first frame to allow simulation to stabilize
+            if frames_captured > 0:
+                # Write the output frame
+                out.write(frame)
+            frames_captured += 1
 
-    logger.debug("Random Movement Simulation succeeded")
-    print("Random Movement Simulation succeeded")
+        logger.debug("Random Movement Simulation succeeded")
+        print("Random Movement Simulation succeeded")
 
-except Exception as e:
-    logger.error("Error during simulation: %s", e)
-    print("Random Movement Simulation failed")
-    raise
+    except Exception as e:
+        logger.error("Error during simulation: %s", e)
+        print("Random Movement Simulation failed")
+        raise
 
-finally:
-    out.release()
-    pygame.quit()
+    finally:
+        out.release()
+        pygame.quit()

--- a/conftest.py
+++ b/conftest.py
@@ -17,3 +17,8 @@ _tmp = tempfile.mkdtemp(prefix="bball_test_")
 os.environ.setdefault("LOG_DIR", _tmp)
 os.environ.setdefault("VIDEO_DIR", _tmp)
 os.environ.setdefault("TRACKING_DIR", _tmp)
+
+# This repo lives in iCloud Drive, which can spawn sync-conflict copies named
+# "<name> 2.py", "<name> 3.py", ... Skip them during collection so they can't
+# pollute or break the test run (they are also gitignored).
+collect_ignore_glob = ["* [0-9].py", "*/* [0-9].py"]

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,19 @@
+"""Shared pytest setup for the basketball pipeline tests.
+
+The simulation modules call pygame.init() and load the court image at import
+time, so pygame must run headless. They also resolve their output directories
+from env vars (falling back to ./<name> off the cwd) -- point the noisy ones at
+a temp dir so test runs don't pollute the repo. ASSETS_DIR is intentionally left
+unset so it defaults to ./assets, where the court image lives.
+"""
+
+import os
+import tempfile
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+
+_tmp = tempfile.mkdtemp(prefix="bball_test_")
+os.environ.setdefault("LOG_DIR", _tmp)
+os.environ.setdefault("VIDEO_DIR", _tmp)
+os.environ.setdefault("TRACKING_DIR", _tmp)

--- a/deep_sort/deep_sort/track.py
+++ b/deep_sort/deep_sort/track.py
@@ -71,6 +71,10 @@ class Track:
         self.hits = 1
         self.age = 1
         self.time_since_update = 0
+        # #12 fix: detector confidence is carried from the matched detection in
+        # update(); None while coasting/unconfirmed (no current detection). Note:
+        # this attribute lives in vendored deep_sort and won't survive a re-vendor.
+        self.confidence = None
 
         self.state = TrackState.Tentative
         self.features = []
@@ -141,6 +145,10 @@ class Track:
         self.features.append(detection.feature)
 
         self.class_id = detection.class_id
+        # #12 fix: carry the matched detection's confidence onto the track so the
+        # logged ConfidenceScore reflects this object (not a positionally
+        # misaligned entry from the detections score array).
+        self.confidence = detection.confidence
 
         self.hits += 1
         self.time_since_update = 0

--- a/nn/pruning.py
+++ b/nn/pruning.py
@@ -15,6 +15,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import torch
+import torch.nn as nn
 import torch.nn.utils.prune as prune
 from tqdm import tqdm
 
@@ -30,14 +31,21 @@ from .training import evaluate_model
 def prune_attention_heads(model, prune_amount=0.2):
     """
     Objective:
-    Prune attention heads based on their importance scores using structured L1 norm
+    Structurally prune the least-important attention heads and PHYSICALLY rebuild
+    the Q/K/V/output projections at the reduced head count, so the parameter and
+    FLOP reduction is real (materialized) rather than just a zero-mask.
+
+    Importance per head combines the learned head_importance scores with the L2
+    norm of that head's Q/K/V projection slices (magnitude-based). The lowest-
+    scoring heads are dropped and the projection matrices are sliced down to the
+    surviving heads. Any pre-existing prune mask is baked in first.
 
     Parameters:
-    [nn.Module] model - The model containing MultiHeadAttention layers to prune
-    [float] prune_amount - Amount of heads to prune (default: 0.2 = 20%)
+    [nn.Module] model - The model containing a MultiHeadAttention layer to prune
+    [float] prune_amount - Fraction of heads to prune (default: 0.2 = 20%)
 
     Returns:
-    [nn.Module] model - The pruned model
+    [nn.Module] model - The pruned model with materially fewer parameters
     """
     try:
         # Verify if the model has the MultiHeadAttention layer
@@ -45,34 +53,82 @@ def prune_attention_heads(model, prune_amount=0.2):
             logger.warning("Model does not have a compatible MultiHeadAttention layer for pruning")
             return model
 
-        # Get the attention module
-        attention_module = model.attention
+        attention = model.attention
+        num_heads = attention.num_heads
+        head_dim = attention.head_dim
 
-        # Apply L1 structured pruning to head_importance
-        prune.ln_structured(
-            attention_module,
-            name='head_importance',
-            amount=prune_amount,
-            n=1,  # L1 norm
-            dim=0  # Prune along dimension 0 (head dimension)
+        # Number of heads to keep (always keep at least one)
+        n_prune = int(round(num_heads * prune_amount))
+        keep_heads = max(1, num_heads - n_prune)
+        if keep_heads >= num_heads:
+            logger.info("Prune amount rounds to 0 heads; model left unchanged")
+            return model
+
+        # Bake any pre-existing head_importance mask into the parameter, then drop
+        # the reparametrization so we operate on plain weights below.
+        if prune.is_pruned(attention):
+            prune.remove(attention, 'head_importance')
+
+        # Per-head importance: learned score * (||Q_h|| + ||K_h|| + ||V_h||)
+        with torch.no_grad():
+            learned = attention.head_importance.detach().abs().view(-1)  # (num_heads,)
+            q = attention.query.weight.detach().view(num_heads, head_dim, -1)
+            k = attention.key.weight.detach().view(num_heads, head_dim, -1)
+            v = attention.value.weight.detach().view(num_heads, head_dim, -1)
+            weight_norm = q.norm(dim=(1, 2)) + k.norm(dim=(1, 2)) + v.norm(dim=(1, 2))
+            score = learned * weight_norm
+
+            # Indices of the heads to keep, in ascending order so the head layout
+            # stays contiguous after slicing.
+            keep_idx = torch.sort(torch.topk(score, keep_heads).indices).values
+
+            # Expand kept-head indices into the row indices of the projection
+            # weights (each head owns head_dim contiguous output rows).
+            row_idx = torch.cat([
+                torch.arange(h * head_dim, (h + 1) * head_dim) for h in keep_idx
+            ])
+
+            new_dim = keep_heads * head_dim
+            in_dim = attention.query.in_features  # unchanged (== attention_dim)
+
+            # Rebuild Q/K/V with fewer output rows (the dropped heads' rows removed)
+            for name in ('query', 'key', 'value'):
+                old = getattr(attention, name)
+                new = nn.Linear(in_dim, new_dim)
+                new.weight = nn.Parameter(old.weight.data[row_idx].clone())
+                new.bias = nn.Parameter(old.bias.data[row_idx].clone())
+                setattr(attention, name, new)
+
+            # Rebuild output projection: input shrinks to new_dim, output stays at
+            # attention_dim so the residual connection still lines up.
+            old_out = attention.output_projection
+            new_out = nn.Linear(new_dim, attention.hidden_dim)
+            new_out.weight = nn.Parameter(old_out.weight.data[:, row_idx].clone())
+            new_out.bias = nn.Parameter(old_out.bias.data.clone())
+            attention.output_projection = new_out
+
+            # Shrink the head-importance vector to the surviving heads
+            attention.head_importance = nn.Parameter(
+                attention.head_importance.data[keep_idx].clone()
+            )
+
+        # Update bookkeeping the forward pass relies on. head_dim (and thus scale)
+        # is unchanged; attention.hidden_dim is the flattened multi-head width used
+        # when reshaping weighted values, so it shrinks to new_dim.
+        attention.num_heads = keep_heads
+        attention.hidden_dim = new_dim
+
+        logger.info(
+            f"Pruned {num_heads - keep_heads}/{num_heads} attention heads "
+            f"({(num_heads - keep_heads)/num_heads:.1%}); attention width "
+            f"{num_heads * head_dim} -> {new_dim}"
         )
-
-        # Log pruning information
-        # Count non-zero rows in head_importance to determine remaining heads
-        remaining_heads = torch.sum(torch.any(attention_module.head_importance != 0, dim=1)).item()
-        total_heads = attention_module.num_heads
-        pruned_heads = total_heads - remaining_heads
-
-        logger.info(f"Pruned {pruned_heads}/{total_heads} attention heads ({pruned_heads/total_heads:.1%})")
-
-        # Make pruning permanent (optional for inference performance)
-        prune.remove(attention_module, 'head_importance')
 
         return model
 
     except Exception as e:
         logger.error(f"Error in prune_attention_heads: {e}")
-        logger.error(f"Pruning skipped, returning original model")
+        logger.error("Pruning skipped, returning original model")
         return model
 
 

--- a/nn/training.py
+++ b/nn/training.py
@@ -15,6 +15,7 @@ from collections import defaultdict
 
 import pandas as pd
 import torch
+import torch.optim as optim
 from sklearn.metrics import precision_score, recall_score, f1_score, confusion_matrix
 from tqdm import tqdm
 
@@ -26,10 +27,10 @@ from .plots import plot_confusion_matrix
 
 #%% Training
 
-def train_model(model, train_loader, val_loader, criterion, optimizer, num_epochs=10, device='cpu', early_stopping_patience=3):
+def train_model(model, train_loader, val_loader, criterion, optimizer, num_epochs=10, device='cpu', early_stopping_patience=3, scheduler=None):
     """
     Objective:
-    Train the LSTM model with validation and early stopping
+    Train the LSTM model with validation, early stopping, and optional LR scheduling
 
     Parameters:
     [nn.Module] model - The LSTM model to train
@@ -40,6 +41,9 @@ def train_model(model, train_loader, val_loader, criterion, optimizer, num_epoch
     [int] num_epochs - Number of epochs to train
     [string] device - Device to train on ('cpu', 'cuda', or 'mps')
     [int] early_stopping_patience - Number of epochs to wait for improvement
+    [lr_scheduler] scheduler - Optional LR scheduler stepped once per epoch. If it
+        is a ReduceLROnPlateau it is stepped with the validation loss, otherwise
+        it is stepped unconditionally.
 
     Returns:
     [dict] history - Training history
@@ -143,6 +147,16 @@ def train_model(model, train_loader, val_loader, criterion, optimizer, num_epoch
             val_precision = precision_score(all_val_labels, all_val_preds, zero_division=0)
             val_recall = recall_score(all_val_labels, all_val_preds, zero_division=0)
             val_f1 = f1_score(all_val_labels, all_val_preds, zero_division=0)
+
+            # Step the LR scheduler once per epoch (plateau schedulers need the
+            # validation loss; others step unconditionally). Record the LR so the
+            # schedule is visible in the training history.
+            if scheduler is not None:
+                if isinstance(scheduler, optim.lr_scheduler.ReduceLROnPlateau):
+                    scheduler.step(val_loss)
+                else:
+                    scheduler.step()
+            history['learning_rate'].append(optimizer.param_groups[0]['lr'])
 
             # Calculate epoch time
             epoch_time = time.time() - epoch_start_time

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+# Put the project root on sys.path so tests can import the top-level pipeline
+# modules (Passing_Simulation, Feature_Engineering, ...). Requires pytest >= 7.0.
+pythonpath = .
+testpaths = tests

--- a/run_sequence.sh
+++ b/run_sequence.sh
@@ -38,10 +38,10 @@ mkdir -p "$LOG_DIR" /app/output/tracking_data /app/output/simulations
 # Run the scripts in sequence
 
 # Passing Simulation
-#log_message "Starting Passing_Simulation.py"
+log_message "Starting Passing_Simulation.py"
 # The 2>&1 redirects both stdout (1) and stderr (2) to the log file
-#python3 Passing_Simulation.py > "$LOG_DIR/Passing_Simulation_output.log" 2>&1
-#check_success "Passing_Simulation"
+python3 Passing_Simulation.py > "$LOG_DIR/Passing_Simulation_output.log" 2>&1
+check_success "Passing_Simulation"
 
 # Random Movement Simulation
 log_message "Starting RandomMovement_Simulation.py"

--- a/tests/quick/test_simulation_math.py
+++ b/tests/quick/test_simulation_math.py
@@ -33,6 +33,10 @@ def helpers():
     extra = {
         'secrets': secrets, 'math': math, 'time': time, 'np': np,
         'logger': logger,
+        # P0-H replaced the stdlib secret-random draws with a seeded module-level
+        # _rng (np.random.default_rng). AST extraction runs these callables in an
+        # isolated namespace, so inject a seeded _rng to satisfy that dependency.
+        '_rng': np.random.default_rng(42),
     }
     cryptographic_normal = load_callable_from_source(
         SIM_PATH, 'cryptographic_normal', extra_globals=extra)

--- a/tests/test_data_loading.py
+++ b/tests/test_data_loading.py
@@ -1,0 +1,55 @@
+"""Behavioral tests for Data_Loading (P0-C).
+
+These cover the DB-independent surface: the ORM exposes the PostGIS column, the
+engine connection string is sourced from the environment, and the distance
+ranking is correct on a known fixture. Tests requiring a live Postgres+PostGIS
+service are out of scope here (skipped via DATABASE_URL conventions in CI).
+"""
+
+import math
+
+import Data_Loading as dl
+
+
+def test_orm_exposes_point_geom():
+    """P0-C: the TrackingData ORM model must define the PostGIS point_geom column."""
+    assert hasattr(dl.TrackingData, 'point_geom')
+    assert 'point_geom' in dl.TrackingData.__table__.columns
+
+
+def test_connection_string_reads_from_env(monkeypatch):
+    monkeypatch.setenv('DATABASE_URL', 'postgresql://u:p@myhost:5432/mydb')
+    assert dl.get_connection_string() == 'postgresql://u:p@myhost:5432/mydb'
+
+
+def test_connection_string_default_when_env_absent(monkeypatch):
+    monkeypatch.delenv('DATABASE_URL', raising=False)
+    assert dl.get_connection_string().startswith('postgresql://')
+
+
+def test_engine_uses_env_connection(monkeypatch):
+    """create_sqlalchemy_engine builds an engine from the env URL. Use a sqlite
+    URL so no external DB driver is required to exercise the full create path."""
+    monkeypatch.setenv('DATABASE_URL', 'sqlite:///:memory:')
+    engine = dl.create_sqlalchemy_engine()
+    assert engine is not None
+    assert str(engine.url) == 'sqlite:///:memory:'
+
+
+def test_distance_calc_known_fixture():
+    """Distances and nearest-first ordering must be correct on a known fixture."""
+    basketball = (0.0, 0.0)
+    players = [
+        (10, 3.0, 4.0),   # distance 5
+        (20, 0.0, 1.0),   # distance 1
+        (30, 6.0, 8.0),   # distance 10
+    ]
+
+    ranked = dl.calculate_point_distances(basketball, players)
+
+    # Sorted nearest-first by id
+    assert [pid for pid, _ in ranked] == [20, 10, 30]
+    # Correct Euclidean magnitudes
+    assert math.isclose(dict(ranked)[20], 1.0)
+    assert math.isclose(dict(ranked)[10], 5.0)
+    assert math.isclose(dict(ranked)[30], 10.0)

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -1,0 +1,58 @@
+"""Behavioral tests for Feature_Engineering (P0-E)."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import Feature_Engineering as fe
+
+
+def test_acceleration_has_no_nan_or_inf_with_zero_delta_time():
+    """First frame per track has delta_time == 0, and velocities can be 0;
+    neither may leak inf/NaN into the acceleration columns."""
+    df = pd.DataFrame(
+        {
+            'TrackID': [1, 1, 1],
+            'Frame': [0, 1, 2],
+            'vel_x': [0.0, 1.0, 2.0],
+            'vel_y': [0.0, 1.0, 2.0],
+            'vel_aspect': [0.0, 0.1, 0.2],
+            'vel_height': [0.0, 1.0, 0.0],  # zero velocity stresses the denominator
+            'delta_time': [0.0, 1 / 30, 1 / 30],  # first frame delta_time == 0
+        }
+    )
+
+    out = fe.extract_acceleration(df)
+
+    for col in ['accel_x', 'accel_y', 'accel_aspect', 'accel_height']:
+        assert np.isfinite(out[col]).all(), f"{col} contains NaN/inf"
+
+
+def test_schema_validator_rejects_missing_columns():
+    incomplete = pd.DataFrame({'Frame': [0], 'TrackID': [1]})
+    with pytest.raises(ValueError):
+        fe.validate_tracking_schema(incomplete)
+
+
+def test_schema_validator_accepts_complete_schema():
+    complete = pd.DataFrame({col: [0] for col in fe.REQUIRED_TRACKING_COLUMNS})
+    assert fe.validate_tracking_schema(complete) is complete
+
+
+def test_pca_flag_toggles_output_dimensionality():
+    """apply_pca_transform (the function the PCA flag invokes) must reduce the
+    numeric feature width while preserving identity/categorical columns."""
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame(rng.random((20, 25)), columns=[f'f{i}' for i in range(25)])
+    df['Frame'] = range(20)
+    df['is_Team_A'] = True
+    df['is_Team_B'] = False
+    df['is_Basketball'] = False
+
+    reduced = fe.apply_pca_transform(df, n_components=5)
+
+    assert reduced.shape[1] < df.shape[1]
+    assert sum(col.startswith('PC') for col in reduced.columns) == 5
+    # preserved columns survive the reduction
+    for col in ['Frame', 'is_Team_A', 'is_Team_B', 'is_Basketball']:
+        assert col in reduced.columns

--- a/tests/test_neural_network.py
+++ b/tests/test_neural_network.py
@@ -1,0 +1,64 @@
+"""Behavioral tests for the nn package's pruning and LR scheduling (P0-D)."""
+
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torch.utils.data import DataLoader
+
+import nn as bnn
+
+
+def _tiny_loader(n=8, seq=4, feat=10):
+    """A minimal loader yielding (padded_features, labels, lengths) batches via
+    the project's own collate function."""
+    data = [(torch.randn(seq, feat), torch.FloatTensor([i % 2])) for i in range(n)]
+    return DataLoader(
+        data, batch_size=4, collate_fn=bnn.collate_variable_length_sequences
+    )
+
+
+def test_pruning_materially_reduces_params_and_runs():
+    """P0-D: pruning must drop the materialized parameter count (not just zero a
+    mask) and the model must still run a forward pass at the reduced head count."""
+    model = bnn.BasketballLSTM(input_dim=10, hidden_dim=16, num_heads=8)
+    params_before = sum(p.numel() for p in model.parameters())
+    heads_before = model.attention.num_heads
+
+    pruned = bnn.prune_attention_heads(model, prune_amount=0.5)
+
+    params_after = sum(p.numel() for p in pruned.parameters())
+    assert params_after < params_before, "pruning did not materially reduce params"
+    assert pruned.attention.num_heads < heads_before
+
+    # Forward pass still works at the reduced head count
+    out, _ = pruned(torch.randn(2, 5, 10))
+    assert out.shape == (2, 1)
+
+
+def test_pruned_head_count_matches_prune_amount():
+    model = bnn.BasketballLSTM(input_dim=10, hidden_dim=16, num_heads=8)
+    bnn.prune_attention_heads(model, prune_amount=0.25)
+    assert model.attention.num_heads == 6  # 8 - round(8*0.25)
+
+
+def test_scheduler_lr_changes_across_epochs(tmp_path, monkeypatch):
+    """train_model must step the scheduler each epoch so the LR changes."""
+    import config
+    # train_model writes history/checkpoints under config.MODEL_DIR; redirect to tmp
+    monkeypatch.setattr(config, 'MODEL_DIR', str(tmp_path))
+
+    model = bnn.BasketballLSTM(input_dim=10, hidden_dim=16, num_heads=8)
+    optimizer = optim.Adam(model.parameters(), lr=0.01)
+    scheduler = optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=3)
+    loader = _tiny_loader()
+
+    lr_before = optimizer.param_groups[0]['lr']
+    history = bnn.train_model(
+        model, loader, loader, nn.BCELoss(), optimizer,
+        num_epochs=2, device='cpu', early_stopping_patience=5, scheduler=scheduler,
+    )
+    lr_after = optimizer.param_groups[0]['lr']
+
+    assert lr_after != lr_before
+    assert len(history['learning_rate']) == 2
+    assert history['learning_rate'][0] != history['learning_rate'][1]

--- a/tests/test_object_tracking.py
+++ b/tests/test_object_tracking.py
@@ -1,0 +1,60 @@
+"""P0-F (#12): confirmed tracks must carry their matched detection's confidence,
+not a positionally misaligned score or 0.0.
+
+Exercises the vendored DeepSORT Tracker directly -- Object_Tracking.py runs a full
+YOLO+video pipeline at import, so the tracking mechanism is validated here at the
+Track/Detection level where the #12 fix lives.
+"""
+
+import numpy as np
+
+from deep_sort.deep_sort import nn_matching
+from deep_sort.deep_sort.detection import Detection
+from deep_sort.deep_sort.tracker import Tracker
+
+
+def _make_detection(box, confidence, class_id):
+    # Distinct appearance feature per object so the matcher keeps them separate
+    feature = np.full(128, float(confidence), dtype=np.float32)
+    return Detection(box, confidence, feature, class_id)
+
+
+def test_track_init_confidence_is_none():
+    metric = nn_matching.NearestNeighborDistanceMetric("euclidean", 0.4, None)
+    tracker = Tracker(metric, n_init=2)
+    tracker.update([_make_detection([100, 100, 20, 40], 0.8, 'Basketball')])
+    # Freshly initiated (not yet updated) track has no detection confidence yet
+    assert tracker.tracks[0].confidence is None
+
+
+def test_confirmed_tracks_carry_matched_confidence_no_swap():
+    metric = nn_matching.NearestNeighborDistanceMetric("euclidean", 0.4, None)
+    tracker = Tracker(metric, n_init=2)
+
+    # Two well-separated detections with distinct, known confidences
+    box_a, conf_a = [100, 100, 20, 40], 0.8
+    box_b, conf_b = [400, 400, 20, 40], 0.9
+
+    for _ in range(4):
+        tracker.predict()
+        tracker.update([
+            _make_detection(box_a, conf_a, 'Basketball'),
+            _make_detection(box_b, conf_b, 'Team_A'),
+        ])
+
+    confirmed = [t for t in tracker.tracks if t.is_confirmed()]
+    assert len(confirmed) >= 2
+
+    confidences = sorted(t.confidence for t in confirmed)
+    # Exactly the two detector confidences, and never the bogus 0.0
+    assert confidences == [conf_a, conf_b]
+    assert all(t.confidence not in (0.0, None) for t in confirmed)
+
+    # Not swapped: the track near box_a's center carries conf_a, box_b -> conf_b.
+    # center_x = top_left_x + w/2 (xyah from the Kalman state mean)
+    for t in confirmed:
+        center_x = t.mean[0]
+        if center_x < 250:
+            assert abs(t.confidence - conf_a) < 1e-6
+        else:
+            assert abs(t.confidence - conf_b) < 1e-6

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -1,0 +1,28 @@
+"""Behavioral tests for the basketball simulation scripts."""
+
+import Passing_Simulation as ps
+
+
+def test_dribble_position_anchors_to_dribbling_player():
+    """P0-A: new_relative_basketball_position must anchor the ball to the
+    dribbling_player argument, not the stale global current_player it used to
+    reference."""
+    dribbling_player = ps.Player(0.0, 0.0, ps.PLAYER_RADIUS, ps.COLOR_BLUE)
+
+    def call():
+        # ball_x, ball_y, randomness, offset, angle, dribbling_player, displacement
+        return ps.new_relative_basketball_position(
+            300.0, 300.0, True, 0.0, 0.0, dribbling_player, 15
+        )
+
+    # With dribbling_player at the origin the function takes the right-side
+    # branch: x stays at ball_x, y = dribbling_player.y + displacement = 15.
+    ps.current_player = ps.Player(0.0, 100.0, ps.PLAYER_RADIUS, ps.COLOR_RED)
+    res_a = call()
+    ps.current_player = ps.Player(0.0, 500.0, ps.PLAYER_RADIUS, ps.COLOR_RED)
+    res_b = call()
+
+    # Anchored to the dribbling_player ...
+    assert res_a == (300.0, 15.0)
+    # ... and independent of whatever the global current_player happens to be.
+    assert res_a == res_b

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -1,6 +1,9 @@
 """Behavioral tests for the basketball simulation scripts."""
 
+import math
+
 import Passing_Simulation as ps
+import RandomMovement_Simulation as rm
 
 
 def test_dribble_position_anchors_to_dribbling_player():
@@ -26,3 +29,91 @@ def test_dribble_position_anchors_to_dribbling_player():
     assert res_a == (300.0, 15.0)
     # ... and independent of whatever the global current_player happens to be.
     assert res_a == res_b
+
+
+# --- P0-H: seeded RNG reproducibility ---------------------------------------
+
+def test_seeded_rng_is_reproducible():
+    """Same seed -> identical sequence of random draws (both sims)."""
+    for mod in (ps, rm):
+        mod.seed_rng(123)
+        first = [float(mod._rng.uniform(0, 1)) for _ in range(5)]
+        mod.seed_rng(123)
+        second = [float(mod._rng.uniform(0, 1)) for _ in range(5)]
+        assert first == second
+
+
+def test_seeded_players_are_identical():
+    """Two players built under the same seed have identical random attributes."""
+    ps.seed_rng(7)
+    p1 = ps.Player(0, 0, ps.PLAYER_RADIUS, ps.COLOR_BLUE)
+    ps.seed_rng(7)
+    p2 = ps.Player(0, 0, ps.PLAYER_RADIUS, ps.COLOR_BLUE)
+    assert p1.speed == p2.speed
+    assert p1.angle == p2.angle
+    assert p1.next_angle == p2.next_angle
+
+
+def test_different_seeds_diverge():
+    ps.seed_rng(1)
+    a = float(ps._rng.uniform(0, 1))
+    ps.seed_rng(2)
+    b = float(ps._rng.uniform(0, 1))
+    assert a != b
+
+
+# --- P0-G: player edge-stick (#13) and ball-receive jerk (#15) ---------------
+
+def test_player_does_not_stick_to_wall():
+    """#13: a player heading into a wall must stay in-bounds every frame and
+    escape the edge band instead of orbiting it."""
+    ps.seed_rng(0)
+    ball = ps.Basketball(0, 0, ps.BALL_RADIUS, ps.COLOR_ORANGE)
+    player = ps.Player(0, 0, ps.PLAYER_RADIUS, ps.COLOR_BLUE)
+
+    max_x = ps.SCREEN_WIDTH - ps.WALL_MARGIN - player.radius
+    max_y = ps.SCREEN_HEIGHT - ps.WALL_MARGIN - player.radius
+
+    # Start adjacent to the right wall, heading outward (angle 0 -> +x)
+    player.x = max_x - 1
+    player.y = ps.SCREEN_HEIGHT / 2
+    player.angle = 0.0
+    player.speed = 2.0
+
+    xs = []
+    for _ in range(120):
+        player.move(ball)
+        xs.append(player.x)
+        # Never leaves the valid interior
+        assert player.radius <= player.x <= max_x
+        assert player.radius <= player.y <= max_y
+
+    # Escaped the right-edge band rather than orbiting it
+    assert min(xs) < max_x - 50
+
+
+def test_ball_approaches_smoothly_with_negative_dx():
+    """#15: moving the ball toward a target that requires negative dx must produce
+    smooth ~MOVE_SPEED steps (no zero-then-jump), not an instant stall."""
+    move_speed = abs(ps.MOVE_SPEED)
+    ball = ps.Basketball(300, 100, ps.BALL_RADIUS, ps.COLOR_ORANGE)
+    target_x, target_y = 50, 100  # to the left of the ball -> dx < 0
+
+    prev = (ball.x, ball.y)
+    steps = []
+    for _ in range(60):
+        ps.move_basketball_to_location(ball, target_x, target_y)
+        steps.append(math.hypot(ball.x - prev[0], ball.y - prev[1]))
+        prev = (ball.x, ball.y)
+        if math.hypot(target_x - ball.x, target_y - ball.y) <= ps.BALL_SNAP_THRESHOLD:
+            break
+
+    # The ball actually started moving (old bug zeroed it because dx < 0)
+    assert steps[0] > 0
+    # No teleport frames
+    assert all(s <= move_speed * 1.5 for s in steps)
+    # Each moving step is a steady ~MOVE_SPEED approach (no zero-then-jump)
+    nonzero = [s for s in steps if s > 1e-9]
+    assert all(abs(s - move_speed) < 1e-6 for s in nonzero)
+    # Reached the snap vicinity of the target
+    assert math.hypot(target_x - ball.x, target_y - ball.y) <= ps.BALL_SNAP_THRESHOLD


### PR DESCRIPTION
- Add pytest.ini (pythonpath) and conftest.py (headless SDL, temp output dirs)
- Passing_Simulation: cwd-local dir fallback when not containerized; guard the
  module-level simulation run behind __main__ so the module is importable
- P0-A: new_relative_basketball_position now anchors the ball to its
  dribbling_player parameter instead of the stale global current_player
- Add tests/test_simulations.py behavioral gate

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>