### PR TITLE
Leverage GPU acceleration via centralized device selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ All stages read paths from env vars with `/app/...` defaults (Docker-oriented). 
 - `OUTPUT_DIR` — root for any other outputs
 - `LOG_DIR` — per-script logs (also where `run_sequence.sh` writes stdout/stderr)
 - `DeepSORT_DIR` — only Object_Tracking.py reads this
+- `DEVICE` — compute device for torch training + YOLO inference. `auto` (default) cascades CUDA → MPS → CPU; set to `cpu`/`cuda`/`mps` to force. Resolved by `config.get_device()`, which also enables `PYTORCH_ENABLE_MPS_FALLBACK` on Apple Silicon. Set `DEVICE=cpu` in CI.
 - `ANTHROPIC_API_KEY` — only `implementation_agent.py` reads this
 
 ## Common commands

--- a/Neural_Network.py
+++ b/Neural_Network.py
@@ -78,15 +78,8 @@ def main():
         # Multi-head attention parameters
         num_heads = config.NUM_HEADS
 
-        # Check device type
-        if torch.cuda.is_available():
-            device = torch.device('cuda')
-        elif torch.backends.mps.is_built() and torch.backends.mps.is_available():
-            device = torch.device('mps')  # Apple Silicon GPU
-        else:
-            device = torch.device('cpu')
-
-        logger.info(f"Using device: {device}")
+        # Resolve compute device (CUDA -> MPS -> CPU, or DEVICE override)
+        device = config.get_device(logger)
 
         # Fit scaler on training data
         logger.info("Fitting scaler on training data...")

--- a/Object_Tracking.py
+++ b/Object_Tracking.py
@@ -68,18 +68,19 @@ def filter_lowconfidence(class_names, scores, basketball_score=config.YOLO_BASKE
 
 #%% Object Tracking with DeepSORT
 
-def object_tracking(frame, model, tracker, encoder, n_missed, detected_objects):
+def object_tracking(frame, model, tracker, encoder, n_missed, detected_objects, device='cpu'):
     """
     Objective:
     Perform deepsort object tracking on each video frame.
-    
+
     Parameters:
     [array] frame - video frame before object tracking
     [class model] model - YOLO detection with the custom model
     [class deepsort] tracker - DeepSORT Tracker
-    [function] encoder - Extracts relevant information (features) from the given frame 
+    [function] encoder - Extracts relevant information (features) from the given frame
     [int] n_missed - number of objects that are tracked (debugging purposes)
     [dataframe] detected_objects - pandas dataframe to store information on detected objects
+    [torch.device] device - Compute device for YOLO inference ('cpu', 'cuda', or 'mps')
 
     Returns:
     [array] frame - video frame after object tracking
@@ -90,7 +91,7 @@ def object_tracking(frame, model, tracker, encoder, n_missed, detected_objects):
     try:
         # Process the current frame with the YOLO model without gradient computation
         with torch.no_grad():
-            results = model(frame)
+            results = model(frame, device=device)
         
         # For each frame, return information on detected objects/inference information 
         print(results)
@@ -311,7 +312,12 @@ except Exception as e:
     logger.error (f"Error: Couldn't find the YOLO model file. {e}")
     exit()
 
+# Resolve compute device (CUDA -> MPS -> CPU, or DEVICE override) and pin the
+# YOLO model to it so detection runs on the GPU when one is available.
+device = config.get_device(logger)
+
 model = YOLO(model_path)
+model.to(device)
 model.info() # Model Information
 model.iou = 0.45
 max_cosine_distance = 0.4
@@ -358,7 +364,7 @@ try:
             break
         
         # Perform DeepSort (Object Tracking)
-        tracked_frame, n_missed, detected_objects = object_tracking(frame_colored, model, tracker, encoder, n_missed, detected_objects)
+        tracked_frame, n_missed, detected_objects = object_tracking(frame_colored, model, tracker, encoder, n_missed, detected_objects, device)
         print('Object Tracking completed')
 
         # Display Video Frame

--- a/README.md
+++ b/README.md
@@ -86,6 +86,19 @@ python Feature_Engineering.py
 python Neural_Network.py
 ```
 
+### GPU acceleration
+
+Object tracking (YOLO detection) and neural network training run on the GPU automatically when one is available. The device is resolved by `config.get_device()`, which cascades **CUDA (NVIDIA) → MPS (Apple Silicon) → CPU**. On Apple Silicon it also enables `PYTORCH_ENABLE_MPS_FALLBACK` so unsupported ops fall back to CPU rather than crashing.
+
+Override the default with the `DEVICE` environment variable:
+
+```bash
+DEVICE=cpu python Neural_Network.py     # force CPU (e.g. in CI)
+DEVICE=cuda python Object_Tracking.py   # force a specific backend
+```
+
+The DeepSORT feature encoder (TensorFlow frozen graph) and feature-engineering PCA (scikit-learn) remain CPU-bound.
+
 If the user would like to levarege Docker containerization, run the following after downloading the code.
 
 ```bash
@@ -116,6 +129,7 @@ Basketball-PlayAnalysis/
 │   ├── Custom_DetectionModel.txt                   # Info / Metrics on custom object detection model
 │   ├── Citations                                   # Citations 
 │   ├── pruning_comparison.png                      # Pruned model compared to oringal model
+├── config.py                                       # Centralized env-var config, hyperparameters, and device selection
 ├── Data_Loading.py                                 # Loading extracted object tracking information into database
 ├── dockerfile                                      # File to setup isolated environment to test code
 ├── Feature_Engineering.py                          # Optimizing the raw object tracking dataset for the neural network

--- a/config.py
+++ b/config.py
@@ -82,6 +82,56 @@ def setup_pipeline_dirs(logger=None):
         print(f"Error in creating environment for containers: {e}")
 
 
+#%% Device selection (GPU acceleration)
+
+# Compute device for torch training and ultralytics/YOLO inference. 'auto'
+# resolves at runtime through CUDA (NVIDIA) -> MPS (Apple Silicon) -> CPU; set
+# DEVICE to 'cpu', 'cuda', or 'mps' to force a backend (e.g. 'cpu' in CI).
+DEVICE = os.environ.get('DEVICE', 'auto')
+
+
+def get_device(logger=None):
+    """
+    Objective:
+    Resolve the torch device to run on. Honors the DEVICE env var and, when it
+    is 'auto', cascades CUDA -> MPS -> CPU. Enables the MPS CPU fallback so
+    unsupported kernels degrade gracefully rather than crashing on Apple Silicon.
+
+    Parameters:
+    [logging.Logger] logger - Optional logger to record the resolved device
+
+    Returns:
+    [torch.device] device - Resolved compute device
+    """
+    # Imported lazily so lightweight stages (e.g. simulations) that import config
+    # don't pay torch's import cost.
+    import torch
+
+    choice = DEVICE.lower()
+
+    if choice == 'auto':
+        if torch.cuda.is_available():
+            resolved = 'cuda'
+        elif torch.backends.mps.is_built() and torch.backends.mps.is_available():
+            resolved = 'mps'  # Apple Silicon GPU
+        else:
+            resolved = 'cpu'
+    else:
+        resolved = choice
+
+    # Route unsupported MPS ops to CPU instead of raising. Checked lazily by the
+    # MPS backend on first miss, so setting it before any op runs is sufficient.
+    if resolved == 'mps':
+        os.environ.setdefault('PYTORCH_ENABLE_MPS_FALLBACK', '1')
+
+    device = torch.device(resolved)
+
+    if logger is not None:
+        logger.info(f"Using device: {device}")
+
+    return device
+
+
 #%% Object_Tracking - YOLO confidence thresholds
 
 # filter_lowconfidence defaults from Object_Tracking.py


### PR DESCRIPTION
## Summary

Adds GPU acceleration across the pipeline where it applies, centered on a single device-selection helper.

- **`config.get_device()`** — new single source of truth for compute-device selection. Reads a new `DEVICE` env var; when `auto` (default) it cascades **CUDA → MPS → CPU**. Enables `PYTORCH_ENABLE_MPS_FALLBACK` on Apple Silicon so unsupported MPS kernels fall back to CPU rather than crashing.
- **`Neural_Network.py`** — replaced the inline device-detection block with `config.get_device(logger)`.
- **`Object_Tracking.py`** — the main gap: previously never set a device. Now pins the YOLO model with `model.to(device)`, passes `device=` into per-frame inference, and threads `device` through `object_tracking()`.
- **Docs** — documented the `DEVICE` env var in `README.md` (new *GPU acceleration* section) and `CLAUDE.md`.

## Out of scope (left CPU-bound by design)

- DeepSORT feature encoder — TensorFlow frozen graph; would need a full PyTorch rewrite.
- `Feature_Engineering.py` PCA / StandardScaler — scikit-learn is CPU-only.

## Verification

- `config.get_device()` resolves `auto → mps` on Apple Silicon; `DEVICE=cpu` override honored.
- Full quick test suite passes (37 passed).
- Set `DEVICE=cpu` in CI/CPU-only runners (auto resolves to CPU there anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)